### PR TITLE
은행 창구 관리 앱 [Step3] 요한, 망고, 밤삭

### DIFF
--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0E0A05562AF0C4B8008E4B1E /* BankManagerConsoleAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E0A05552AF0C4B8008E4B1E /* BankManagerConsoleAppTests.swift */; };
 		0E0A055C2AF0C71E008E4B1E /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F581EFE2AF0BA4B00C00065 /* Queue.swift */; };
+		0E7AADB22AFB6BCD002C02F2 /* TaskType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E7AADB12AFB6BCD002C02F2 /* TaskType.swift */; };
 		66493A582AF384AE00413019 /* Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66493A572AF384AE00413019 /* Client.swift */; };
 		66493A592AF384B700413019 /* Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66493A572AF384AE00413019 /* Client.swift */; };
 		66493A5C2AF3921900413019 /* Bank.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66493A5B2AF3921900413019 /* Bank.swift */; };
@@ -34,6 +35,7 @@
 /* Begin PBXFileReference section */
 		0E0A05532AF0C4B8008E4B1E /* BankManagerConsoleAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BankManagerConsoleAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		0E0A05552AF0C4B8008E4B1E /* BankManagerConsoleAppTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankManagerConsoleAppTests.swift; sourceTree = "<group>"; };
+		0E7AADB12AFB6BCD002C02F2 /* TaskType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskType.swift; sourceTree = "<group>"; };
 		66493A572AF384AE00413019 /* Client.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Client.swift; sourceTree = "<group>"; };
 		66493A5B2AF3921900413019 /* Bank.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bank.swift; sourceTree = "<group>"; };
 		666F27FE2AF9F02A00786A1B /* BankProcess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankProcess.swift; sourceTree = "<group>"; };
@@ -76,6 +78,7 @@
 				C7D65D1A259C8190005510E0 /* BankManager.swift */,
 				66493A572AF384AE00413019 /* Client.swift */,
 				66493A5B2AF3921900413019 /* Bank.swift */,
+				0E7AADB12AFB6BCD002C02F2 /* TaskType.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -230,6 +233,7 @@
 				7F8059C72AFA03AA00948DCB /* BankManagable.swift in Sources */,
 				66493A5C2AF3921900413019 /* Bank.swift in Sources */,
 				66493A582AF384AE00413019 /* Client.swift in Sources */,
+				0E7AADB22AFB6BCD002C02F2 /* TaskType.swift in Sources */,
 				C7D65D1B259C8190005510E0 /* BankManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankProcess.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankProcess.swift
@@ -10,8 +10,8 @@ import Foundation
 final class BankProcess {
     private let bank: Bank
     
-    init(clerkCount: Int) {
-        let bankManager: BankManagable = BankManager(clerkCount)
+    init(loanClerkCount: Int, depositClerkCount: Int) {
+        let bankManager: BankManagable = BankManager(loanClerkCount: loanClerkCount, depositClerkCount: depositClerkCount)
         self.bank = Bank(bankManager: bankManager)
     }
     

--- a/BankManagerConsoleApp/BankManagerConsoleApp/BankProcess.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/BankProcess.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  BankProcess.swift
 //  BankManagerConsoleApp
 //
 //  Created by 김예준 on 11/7/23.

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
@@ -26,7 +26,8 @@ struct Bank {
     
     private func beginReception(count: Int) {
         for i in 1...count {
-            let client = Client(id: i)
+            guard let taskType = TaskType.allCases.randomElement() else { return }
+            let client = Client(id: i, taskType: taskType)
             self.bankManager.recept(for: client)
         }
     }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankManager.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankManager.swift
@@ -58,9 +58,9 @@ extension BankManager {
         var description: String {
             switch self {
             case .start(let client):
-                return "\(client) 업무 시작"
+                return "\(client) \(client.taskType)업무 시작"
             case .end(let client):
-                return "\(client) 업무 완료"
+                return "\(client) \(client.taskType)업무 완료"
             }
         }
     }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Client.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Client.swift
@@ -18,4 +18,3 @@ struct Client: CustomStringConvertible {
         "\(self.id)번 고객"
     }
 }
-

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Client.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Client.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct Client: CustomStringConvertible {
     private let id: Int
-    private let taskType: TaskType
+    let taskType: TaskType
     
     init(id: Int, taskType: TaskType) {
         self.id = id

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Client.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Client.swift
@@ -9,9 +9,11 @@ import Foundation
 
 struct Client: CustomStringConvertible {
     private let id: Int
+    private let taskType: TaskType
     
-    init(id: Int) {
+    init(id: Int, taskType: TaskType) {
         self.id = id
+        self.taskType = taskType
     }
     
     var description: String {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/TaskType.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/TaskType.swift
@@ -1,0 +1,31 @@
+//
+//  TaskType.swift
+//  BankManagerConsoleApp
+//
+//  Created by 동준 on 11/8/23.
+//
+
+import Foundation
+
+enum TaskType: CustomStringConvertible, CaseIterable {
+    case loan
+    case deposit
+    
+    var description: String {
+        switch self {
+        case .loan:
+            return "대출"
+        case .deposit:
+            return "예금"
+        }
+    }
+    
+    var requiredTime: Double {
+        switch self {
+        case .loan:
+            return 1.1
+        case .deposit:
+            return 0.7
+        }
+    }
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/main.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-let bankProcess = BankProcess(clerkCount: 1)
+let bankProcess = BankProcess(loanClerkCount: 1, depositClerkCount: 2)
 
 bankProcess.run()
 


### PR DESCRIPTION
# 은행창구 관리 앱

리뷰어: @jryoun1
## 팀원:busts_in_silhouette: 
| 프로필 사진 | <a href="https://github.com/Dongjun-developer"><img src="https://avatars.githubusercontent.com/u/97822621?v=4" width="90" height="90"></a> | <a href="https://github.com/bamsak"><img src="https://avatars.githubusercontent.com/u/114239407?v=4" width=90></a> | <a href="https://github.com/dpwns1234"><img src="https://avatars.githubusercontent.com/u/52391722?v=4" width=90></a> |
| ---- | ---------- | --------- | --------- |
| in Github | [@DongJun](https://github.com/Dongjun-developer) | [@bamsak](https://github.com/bamsak) | [@dpwns1234](https://github.com/dpwns1234) |
| in SeSAC | 망고 | 밤삭 | 요한 |

안녕하세요 제이크!
은행창구 관리 앱 STEP3 PR 보냅니다. 잘 부탁드립니다 🙇🏻‍♂️🙇‍♀️


## 파일구조:file_folder:
- BankManagerConsoleApp
- Protocol
    - BankManagable.swift
- Model
    -  BankManager.swift
    -  Bank.swift
    -  Client.swift
    -  TaskType.swift
- Utility
    - Queue.swift
- BankProcess.swift
- main.swift
- BankManagerConsoleAppTests
    - BankManagerConsoleApp.swift


## 프로젝트 진행 과정

### 고객의 업무 타입 구현
> `CaseIterable`프로토콜을 채택해 `TaskType`을 배열로 만들어 `randomElement()`메소드를 통해 고객 생성시 고객이 가질 업무 타입을 주입해주었습니다.
> `TaskType`내부에 `requiredTime`이라는 연산 프로퍼티를 구현하여 고객의 업무 타입에 따라 `Thread.sleep`의 매개변수로 넘겨주도록 하였습니다.
<details>
    <summary>코드 예시</summary>
<div markdown="1">
    
```swift=
// TaskType.swift
    
enum TaskType: CustomStringConvertible, CaseIterable {
    case loan
    case deposit
    
    var description: String {
        switch self {
        case .loan:
            return "대출"
        case .deposit:
            return "예금"
        }
    }
    
    var requiredTime: Double {
        switch self {
        case .loan:
            return 1.1
        case .deposit:
            return 0.7
        }
    }
}
```

```swift=
// Bank.swift
    
private func beginReception(count: Int) {
    for i in 1...count {
        guard let taskType = TaskType.allCases.randomElement() else { return }
        let client = Client(id: i, taskType: taskType)
        self.bankManager.recept(for: client)
    }
}
```
```swift=
// BankManager.swift
    
private func task(for client: Client) {
    print(WorkState.start(client: client))
    self.working(for: client.taskType.requiredTime)
    print(WorkState.end(client: client))
}

private func working(for time: Double) {
    Thread.sleep(forTimeInterval: time)
    self.totalWorkTime += time
}
```
</div>
</details>


### ClientQueue.dequeue를 수행하기 전에 peek를 해주는 이유
> 고객의 업무 타입으로 `BankManager`가 대출부서, 예금부서로 관리하여 정해진 각 부서로 안내하여 정해진 은행원(Thread)만 가지고 고객업무를 대응하도록 하였습니다. `ClientQueue`에서 `peek`을 해서 얻어온 정보로 이번 차례의 `client`가 어떤 부서로 배정할 지를 정해주고 그 후에 각 부서의 은행원(Thread)가 client를 맞이하여 업무를 처리합니다.

> 고객의 업무 타입에 따라 각기 다른 `DispatchSemaphore`로 Thread관리를 위해 `DispatchSemaphore`를 매개변수로 받고 재사용할 수 있도록 `callClient`메소드로 구현하였습니다.

> client 업무 타입`(taskType)`을 알기 위해 `dequeue`를 호출하여 비교할 경우, `DispatchSemaphore`의 `wait`이 호출되기 전에 `dequeue`작업이 먼저 진행되기 때문에, 업무 시작 상태로 들어가지 않는 `client`가 `clientQueue`에서 `dequeue`된 상태로 앞의 client의 업무가 끝나길 기다리는 상태가 되었습니다.
즉, **고객을 부르고 아직 이전 고객에 대한 업무가 끝나지 않아서 기다리게 한다는 점**이 이상하다고 생각되었습니다. 그리하여 `peek`으로 client의 업무 타입을 가져와 비교한 후, `dequeue`를 진행하도록 하였습니다. 


<details>
<summary>코드 예시</summary>
<div markdown="1">

```swift=
// BankManager.swift
    
private let loanSemaphore: DispatchSemaphore
private let depositSemaphore: DispatchSemaphore
    
init(loanClerkCount: Int, depositClerkCount: Int) {
    self.loanSemaphore = DispatchSemaphore(value: loanClerkCount)
    self.depositSemaphore = DispatchSemaphore(value: depositClerkCount)
}    
    
func startWork() {
        let group = DispatchGroup()
        
        while self.clientQueue.isEmpty == false {
            guard let client = self.clientQueue.peek else { return }
            switch client.taskType {
            case .loan:
                self.callClient(semaphore: loanSemaphore, group: group)
            case .deposit:
                self.callClient(semaphore: depositSemaphore, group: group)
            }
        }
        
        group.wait()
    }    
    
    
 private func callClient(semaphore: DispatchSemaphore, group: DispatchGroup) {
        semaphore.wait()
        DispatchQueue.global().async(group: group) {
            self.task(for: client)
            semaphore.signal()
        }
    }
```
    
    
    
**before** 아래는 dequeue먼저 호출 후, semaphore.wait()을 준 코드입니다.
``` swift=
// before

    func startWork() {
        let group = DispatchGroup()
        
        while self.clientQueue.isEmpty == false {
            guard let client = self.clientQueue.dequeue() else { return }
            switch client.taskType {
            case .loan:
                self.callClient(semaphore: loanSemaphore, group: group, client: client)
            case .deposit:
                self.callClient(semaphore: depositSemaphore, group: group, client: client)
            }
        }
        
        group.wait()
    }
    
    
     private func callClient(semaphore: DispatchSemaphore, group: DispatchGroup, client: Client) {
        semaphore.wait()
        DispatchQueue.global().async(group: group) {
            self.task(for: client)
            semaphore.signal()
        }
    }

```
</div>
</details>


## 프로젝트 하면서 고민한 점
### Client의 taskType의 은닉화에 대한 고민
Client의 taskType을 은닉화를 위해 3가지 방법을 생각해봤습니다.
1. private(set) var: 객체 외부에서는 수정할 수 없으나, 객체 내부에서 수정 가능성이 있기에 
2. private let + get(): 객체 내/외부에서 수정할 수 없으나, taskType이 while문에서 사용되는 만큼 프로퍼티로 접근하는 것보다 함수로 접근하는 것이 메모리에 부담이 되진 않을까 생각하였습니다. (컴파일러가 알아서 inline 함수로 바꿔줄 것 같긴 하지만 확실치 않습니다..)
3. internal let: 객체 내/외부에서 수정할 수 없으며 접근만 가능할 수 있지만, private을 써주지 않아서 은닉화/캡슐화를 제대로 해주지 않은 듯한 느낌이 듭니다.
        
코드에서는 Client의 taskType을 interal let으로 두었는데 제이크는 어떻게 생각하는 지 여쭤봅니다.