### PR TITLE
은행 창구 관리 앱 [STEP3] Jin, Loffy

### DIFF
--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		F31EDDBF2B68C7F200CBB73E /* BankClerk.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31EDDBE2B68C7F200CBB73E /* BankClerk.swift */; };
 		F31EDDC12B68D1A900CBB73E /* BankMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31EDDC02B68D1A900CBB73E /* BankMessage.swift */; };
 		F3A904232B60AC5D001E00E7 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3A904222B60AC5D001E00E7 /* LinkedList.swift */; };
+		F3CE19072B72262B000FC3F0 /* BankingList.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3CE19062B72262B000FC3F0 /* BankingList.swift */; };
 		F3F4F95A2B621E4C0037A3AF /* CustomerQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3F4F9592B621E4C0037A3AF /* CustomerQueue.swift */; };
 /* End PBXBuildFile section */
 
@@ -48,6 +49,7 @@
 		F31EDDBE2B68C7F200CBB73E /* BankClerk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankClerk.swift; sourceTree = "<group>"; };
 		F31EDDC02B68D1A900CBB73E /* BankMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankMessage.swift; sourceTree = "<group>"; };
 		F3A904222B60AC5D001E00E7 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
+		F3CE19062B72262B000FC3F0 /* BankingList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BankingList.swift; path = "../../../../ios-bank-manager_temp/BankManagerConsoleApp/BankManagerConsoleApp/Enums/BankingList.swift"; sourceTree = "<group>"; };
 		F3F4F9592B621E4C0037A3AF /* CustomerQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerQueue.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -130,6 +132,7 @@
 			children = (
 				F31EDDC02B68D1A900CBB73E /* BankMessage.swift */,
 				F31EDDAA2B63996700CBB73E /* Constants.swift */,
+				F3CE19062B72262B000FC3F0 /* BankingList.swift */,
 			);
 			path = Enums;
 			sourceTree = "<group>";
@@ -250,6 +253,7 @@
 				F3F4F95A2B621E4C0037A3AF /* CustomerQueue.swift in Sources */,
 				F31EDDBB2B68C6A200CBB73E /* Customer.swift in Sources */,
 				F31EDD952B63911400CBB73E /* main.swift in Sources */,
+				F3CE19072B72262B000FC3F0 /* BankingList.swift in Sources */,
 				F3A904232B60AC5D001E00E7 /* LinkedList.swift in Sources */,
 				F31EDDBD2B68C72600CBB73E /* Bank.swift in Sources */,
 				F31EDDBF2B68C7F200CBB73E /* BankClerk.swift in Sources */,

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -20,8 +20,8 @@
 		F31EDDBF2B68C7F200CBB73E /* BankClerk.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31EDDBE2B68C7F200CBB73E /* BankClerk.swift */; };
 		F31EDDC12B68D1A900CBB73E /* BankMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31EDDC02B68D1A900CBB73E /* BankMessage.swift */; };
 		F3A904232B60AC5D001E00E7 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3A904222B60AC5D001E00E7 /* LinkedList.swift */; };
-		F3CE19072B72262B000FC3F0 /* BankingList.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3CE19062B72262B000FC3F0 /* BankingList.swift */; };
 		F3CE190A2B722B22000FC3F0 /* BankView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3CE19092B722B22000FC3F0 /* BankView.swift */; };
+		F3CE190C2B731C70000FC3F0 /* BankingList.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3CE190B2B731C70000FC3F0 /* BankingList.swift */; };
 		F3F4F95A2B621E4C0037A3AF /* CustomerQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3F4F9592B621E4C0037A3AF /* CustomerQueue.swift */; };
 /* End PBXBuildFile section */
 
@@ -50,8 +50,8 @@
 		F31EDDBE2B68C7F200CBB73E /* BankClerk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankClerk.swift; sourceTree = "<group>"; };
 		F31EDDC02B68D1A900CBB73E /* BankMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankMessage.swift; sourceTree = "<group>"; };
 		F3A904222B60AC5D001E00E7 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
-		F3CE19062B72262B000FC3F0 /* BankingList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BankingList.swift; path = "../../../../ios-bank-manager_temp/BankManagerConsoleApp/BankManagerConsoleApp/Enums/BankingList.swift"; sourceTree = "<group>"; };
 		F3CE19092B722B22000FC3F0 /* BankView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankView.swift; sourceTree = "<group>"; };
+		F3CE190B2B731C70000FC3F0 /* BankingList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BankingList.swift; sourceTree = "<group>"; };
 		F3F4F9592B621E4C0037A3AF /* CustomerQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerQueue.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -135,7 +135,7 @@
 			children = (
 				F31EDDC02B68D1A900CBB73E /* BankMessage.swift */,
 				F31EDDAA2B63996700CBB73E /* Constants.swift */,
-				F3CE19062B72262B000FC3F0 /* BankingList.swift */,
+				F3CE190B2B731C70000FC3F0 /* BankingList.swift */,
 			);
 			path = Enums;
 			sourceTree = "<group>";
@@ -265,10 +265,10 @@
 				F3F4F95A2B621E4C0037A3AF /* CustomerQueue.swift in Sources */,
 				F31EDDBB2B68C6A200CBB73E /* Customer.swift in Sources */,
 				F31EDD952B63911400CBB73E /* main.swift in Sources */,
-				F3CE19072B72262B000FC3F0 /* BankingList.swift in Sources */,
 				F3A904232B60AC5D001E00E7 /* LinkedList.swift in Sources */,
 				F31EDDBD2B68C72600CBB73E /* Bank.swift in Sources */,
 				F31EDDBF2B68C7F200CBB73E /* BankClerk.swift in Sources */,
+				F3CE190C2B731C70000FC3F0 /* BankingList.swift in Sources */,
 				F31EDDC12B68D1A900CBB73E /* BankMessage.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
+++ b/BankManagerConsoleApp/BankManagerConsoleApp.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		F31EDDC12B68D1A900CBB73E /* BankMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31EDDC02B68D1A900CBB73E /* BankMessage.swift */; };
 		F3A904232B60AC5D001E00E7 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3A904222B60AC5D001E00E7 /* LinkedList.swift */; };
 		F3CE19072B72262B000FC3F0 /* BankingList.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3CE19062B72262B000FC3F0 /* BankingList.swift */; };
+		F3CE190A2B722B22000FC3F0 /* BankView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3CE19092B722B22000FC3F0 /* BankView.swift */; };
 		F3F4F95A2B621E4C0037A3AF /* CustomerQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3F4F9592B621E4C0037A3AF /* CustomerQueue.swift */; };
 /* End PBXBuildFile section */
 
@@ -50,6 +51,7 @@
 		F31EDDC02B68D1A900CBB73E /* BankMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankMessage.swift; sourceTree = "<group>"; };
 		F3A904222B60AC5D001E00E7 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
 		F3CE19062B72262B000FC3F0 /* BankingList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BankingList.swift; path = "../../../../ios-bank-manager_temp/BankManagerConsoleApp/BankManagerConsoleApp/Enums/BankingList.swift"; sourceTree = "<group>"; };
+		F3CE19092B722B22000FC3F0 /* BankView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BankView.swift; sourceTree = "<group>"; };
 		F3F4F9592B621E4C0037A3AF /* CustomerQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerQueue.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -119,6 +121,7 @@
 			isa = PBXGroup;
 			children = (
 				F31EDD942B63911400CBB73E /* main.swift */,
+				F3CE19082B722B05000FC3F0 /* View */,
 				22AB1BF52B68D5CB00241B0F /* Controller */,
 				F31EDDA92B63988B00CBB73E /* Enums */,
 				F3F4F95B2B62231D0037A3AF /* Model */,
@@ -135,6 +138,14 @@
 				F3CE19062B72262B000FC3F0 /* BankingList.swift */,
 			);
 			path = Enums;
+			sourceTree = "<group>";
+		};
+		F3CE19082B722B05000FC3F0 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				F3CE19092B722B22000FC3F0 /* BankView.swift */,
+			);
+			path = View;
 			sourceTree = "<group>";
 		};
 		F3F4F95B2B62231D0037A3AF /* Model */ = {
@@ -247,6 +258,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F3CE190A2B722B22000FC3F0 /* BankView.swift in Sources */,
 				F31EDDAB2B63996700CBB73E /* Constants.swift in Sources */,
 				229B94BE2B60AA9E003320F6 /* Node.swift in Sources */,
 				22AB1BF12B68CA1600241B0F /* BankManager.swift in Sources */,

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Controller/BankManager.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Controller/BankManager.swift
@@ -2,18 +2,28 @@
 //  BankManager.swift
 //  BankManagerConsoleApp
 //
-//  Created by 김동준 on 1/30/24.
+//  Created by 루피, 진 on 1/30/24.
 //
 
-import Foundation
+protocol BankManagerProtocol {
+    func sendWorkingMessage(_ message: String)
+}
 
-struct BankManager {
-    var isRunning: Bool = true
-    var bank = Bank()
+struct BankManager: BankManagerProtocol {
+    
+    var isRunning: Bool
+    var bank: Bank
+    let bankView: BankViewProtocol
+     
+    init(isRunning: Bool = true, bank: Bank = Bank(), bankView: BankViewProtocol = BankView()) {
+        self.isRunning = isRunning
+        self.bank = bank
+        self.bankView = bankView
+    }
     
     mutating func run() {
         while isRunning {
-            print(BankMessage.bankMenu.description, terminator: "")
+            bankView.printConsolView(message: BankMessage.bankMenu.description, terminator: "")
             
             switch fetchUserInput() {
             case "1":
@@ -23,7 +33,7 @@ struct BankManager {
                 isRunning = false
                 break
             default:
-                print(BankMessage.request.description)
+                bankView.printConsolView(message: BankMessage.request.description, terminator: nil)
                 continue
             }
         }
@@ -32,5 +42,9 @@ struct BankManager {
     private func fetchUserInput() -> String {
         guard let inputText = readLine() else { return Constants.userInputError }
         return inputText
+    }
+    
+    func sendWorkingMessage(_ message: String) {
+        bankView.printConsolView(message: message, terminator: nil)
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/DataStructure/CustomerQueue.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/DataStructure/CustomerQueue.swift
@@ -5,14 +5,14 @@
 //  Created by Jin-Mac on 1/25/24.
 //
 
-struct CustomerQueue<T: Equatable> {
+class CustomerQueue<T: Equatable> {
     var list = LinkedList<T>()
     
-    mutating func enqueue(value: T) {
+    func enqueue(value: T) {
         list.append(value: value)
     }
     
-    mutating func dequeue() -> T? {
+    func dequeue() -> T? {
         let result = list.remove(at: 0)
         return result?.value
     }
@@ -21,7 +21,7 @@ struct CustomerQueue<T: Equatable> {
         return list.first()?.value
     }
     
-    mutating func clear() {
+    func clear() {
         list.removeAll()
     }
     

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Enums/BankMessage.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Enums/BankMessage.swift
@@ -2,13 +2,13 @@
 //  BankMessage.swift
 //  BankManagerConsoleApp
 //
-//  Created by Jin-Mac on 1/30/24.
+//  Created by 루피, 진 on 1/30/24.
 //
 
 enum BankMessage: CustomStringConvertible {
     case bankMenu
-    case start(Int)
-    case done(Int)
+    case start(Int, String)
+    case done(Int , String)
     case result(Int, String)
     case request
     
@@ -18,10 +18,10 @@ enum BankMessage: CustomStringConvertible {
             return "1 : 은행 개점\n2 : 종료\n입력 : "
         case .request:
             return "잘못 입력 했습니다. 다시 입력 해주세요."
-        case .start(let number):
-            return "\(number)번 고객 업무 시작"
-        case .done(let number):
-            return "\(number)번 고객 업무 종료"
+        case .start(let number, let task):
+            return "\(number)번 고객 \(task)업무 시작"
+        case .done(let number, let task):
+            return "\(number)번 \(task)고객 업무 종료"
         case .result(let customerCount, let intervalTime):
             return "업무가 마감되었습니다. 오늘 업무를 처리한 고객은 총 \(customerCount)명이며, 총 업무시간은 \(intervalTime)입니다."
         }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Enums/BankingList.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Enums/BankingList.swift
@@ -1,0 +1,11 @@
+//
+//  BankingList.swift
+//  BankManagerConsoleApp
+//
+//  Created by Jin-Mac on 2/6/24.
+//
+
+enum Banking: String, CaseIterable {
+    case deposit = "예금"
+    case loan = "대출"
+}

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
@@ -93,7 +93,7 @@ extension Bank {
             workDepositSecond()
             workLoanFirst()
         }
-        
+
         watingGroup.wait()
         let totalTime = caculateProcessingTime(startTime)
         BankManager().sendWorkingMessage("\(BankMessage.result(customerCount, totalTime).description)")

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
@@ -8,12 +8,27 @@
 import Foundation
 
 struct Bank {
-    var bankWatingQueue = CustomerQueue<Customer>()
-    var clerk: BankClerk
+    var depositWatingQueue = CustomerQueue<Customer>()
+    var loanWatingQueue = CustomerQueue<Customer>()
+    var depositClerkFirst: BankClerk
+    var depositClerkSecond: BankClerk
+    var loanClerkFirst: BankClerk
+    var customerCount = 0
+    let depositSemaphore = DispatchSemaphore(value: 2)
+    let loanSemaphore = DispatchSemaphore(value: 1)
+    let watingGroup = DispatchGroup()
     
-    init(clerk: BankClerk = BankClerk()) {
-        self.clerk = clerk
+    
+    init(depositClerkFirst: BankClerk = BankClerk(),
+         depositClerkSecond: BankClerk = BankClerk(),
+         loanClerkFirst: BankClerk = BankClerk()) {
+        self.depositClerkFirst = depositClerkFirst
+        self.depositClerkSecond = depositClerkSecond
+        self.loanClerkFirst = loanClerkFirst
     }
+}
+
+extension Bank {
     
     mutating func open() {
         setWatingLine()
@@ -21,27 +36,61 @@ struct Bank {
     }
     
     private mutating func setWatingLine() {
-        let customerCount: Int = Int.random(in: 10...30)
+        self.customerCount = Int.random(in: 10...30)
         
         for count in 1...customerCount {
-            bankWatingQueue.enqueue(value: Customer(number: count))
+            guard let task = Banking.allCases.randomElement() else { return }
+            switch task {
+            case .deposit:
+                depositWatingQueue.enqueue(value: Customer(number: count, task: task))
+            case .loan:
+                loanWatingQueue.enqueue(value: Customer(number: count, task: task))
+            }
+        }
+    }
+    
+    private mutating func workDepositFirst() {
+        guard !depositWatingQueue.isEmpty() else { return }
+        depositSemaphore.wait()
+        DispatchQueue.global().async(group: watingGroup) { [self] in
+            guard let customer = depositWatingQueue.dequeue() else { return }
+            depositClerkFirst.depositWorking(for: customer)
+            depositSemaphore.signal()
+        }
+    }
+    
+    private mutating func workDepositSecond() {
+        guard !depositWatingQueue.isEmpty() else { return }
+        depositSemaphore.wait()
+        DispatchQueue.global().async(group: watingGroup) { [self] in
+            guard let customer = depositWatingQueue.dequeue() else { return }
+            depositClerkSecond.depositWorking(for: customer)
+            depositSemaphore.signal()
+        }
+    }
+    
+    private mutating func workLoanFirst() {
+        guard !loanWatingQueue.isEmpty() else { return }
+        loanSemaphore.wait()
+        DispatchQueue.global().async(group: watingGroup) { [self] in
+            guard let customer = loanWatingQueue.dequeue() else { return }
+            loanClerkFirst.lendWorking(for: customer)
+            loanSemaphore.signal()
         }
     }
     
     private mutating func excuteBankWork() {
         let startTime = CFAbsoluteTimeGetCurrent()
-        var count = 0
         
-        DispatchQueue.global().sync {
-            while !bankWatingQueue.isEmpty() {
-                guard let customer = bankWatingQueue.dequeue() else { return }
-                clerk.work(for: customer)
-                count += 1
-            }
+        while !depositWatingQueue.isEmpty() || !loanWatingQueue.isEmpty() {
+            workDepositFirst()
+            workDepositSecond()
+            workLoanFirst()
         }
         
+        watingGroup.wait()
         let totalTime = caculateProcessingTime(startTime)
-        print(BankMessage.result(count, totalTime).description)
+        print(BankMessage.result(customerCount, totalTime).description)
     }
     
     private func caculateProcessingTime(_ startTime: CFAbsoluteTime) -> String {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Bank.swift
@@ -54,8 +54,10 @@ extension Bank {
         depositSemaphore.wait()
         DispatchQueue.global().async(group: watingGroup) { [self] in
             guard let customer = depositWatingQueue.dequeue() else { return }
-            depositClerkFirst.depositWorking(for: customer)
+            BankManager().sendWorkingMessage("\(BankMessage.start(customer.number, "예금").description)")
+            depositClerkFirst.depositWorking()
             depositSemaphore.signal()
+            BankManager().sendWorkingMessage("\(BankMessage.done(customer.number, "예금").description)")
         }
     }
     
@@ -64,8 +66,10 @@ extension Bank {
         depositSemaphore.wait()
         DispatchQueue.global().async(group: watingGroup) { [self] in
             guard let customer = depositWatingQueue.dequeue() else { return }
-            depositClerkSecond.depositWorking(for: customer)
+            BankManager().sendWorkingMessage("\(BankMessage.start(customer.number, "예금").description)")
+            depositClerkSecond.depositWorking()
             depositSemaphore.signal()
+            BankManager().sendWorkingMessage("\(BankMessage.done(customer.number, "예금").description)")
         }
     }
     
@@ -74,8 +78,10 @@ extension Bank {
         loanSemaphore.wait()
         DispatchQueue.global().async(group: watingGroup) { [self] in
             guard let customer = loanWatingQueue.dequeue() else { return }
-            loanClerkFirst.lendWorking(for: customer)
+            BankManager().sendWorkingMessage("\(BankMessage.start(customer.number, "대출").description)")
+            loanClerkFirst.lendWorking()
             loanSemaphore.signal()
+            BankManager().sendWorkingMessage("\(BankMessage.done(customer.number, "대출").description)")
         }
     }
     
@@ -90,7 +96,13 @@ extension Bank {
         
         watingGroup.wait()
         let totalTime = caculateProcessingTime(startTime)
-        print(BankMessage.result(customerCount, totalTime).description)
+        BankManager().sendWorkingMessage("\(BankMessage.result(customerCount, totalTime).description)")
+        resetSetting()
+    }
+    
+    private func resetSetting() {
+        depositSemaphore.signal()
+        loanSemaphore.signal()
     }
     
     private func caculateProcessingTime(_ startTime: CFAbsoluteTime) -> String {

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankClerk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankClerk.swift
@@ -8,7 +8,7 @@ import Foundation
 
 struct BankClerk {
     
-    func work(for customer: Customer) {
+    func depositWorking(for customer: Customer) {
         print(BankMessage.start(customer.number, "예금").description)
         Thread.sleep(forTimeInterval: 0.7)
         print(BankMessage.done(customer.number, "예금").description)

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankClerk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankClerk.swift
@@ -2,14 +2,21 @@
 //  BankClerk.swift
 //  BankManagerConsoleApp
 //
-//  Created by Jin-Mac on 1/30/24.
+//  Created by 루피, 진 on 1/30/24.
 //
 import Foundation
 
 struct BankClerk {
+    
     func work(for customer: Customer) {
-        print(BankMessage.start(customer.number).description)
+        print(BankMessage.start(customer.number, "예금").description)
         Thread.sleep(forTimeInterval: 0.7)
-        print(BankMessage.done(customer.number).description)
+        print(BankMessage.done(customer.number, "예금").description)
+    }
+    
+    func lendWorking(for customer: Customer) {
+        print(BankMessage.start(customer.number, "대출").description)
+        Thread.sleep(forTimeInterval: 1.1)
+        print(BankMessage.done(customer.number, "대출").description)
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankClerk.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/BankClerk.swift
@@ -8,15 +8,11 @@ import Foundation
 
 struct BankClerk {
     
-    func depositWorking(for customer: Customer) {
-        print(BankMessage.start(customer.number, "예금").description)
+    func depositWorking() {
         Thread.sleep(forTimeInterval: 0.7)
-        print(BankMessage.done(customer.number, "예금").description)
     }
     
-    func lendWorking(for customer: Customer) {
-        print(BankMessage.start(customer.number, "대출").description)
+    func lendWorking() {
         Thread.sleep(forTimeInterval: 1.1)
-        print(BankMessage.done(customer.number, "대출").description)
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/Model/Customer.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/Model/Customer.swift
@@ -7,8 +7,10 @@
 
 struct Customer: Equatable {
     let number: Int
+    let task: Banking
     
-    init(number: Int) {
+    init(number: Int, task: Banking) {
         self.number = number
+        self.task = task
     }
 }

--- a/BankManagerConsoleApp/BankManagerConsoleApp/View/BankView.swift
+++ b/BankManagerConsoleApp/BankManagerConsoleApp/View/BankView.swift
@@ -1,0 +1,19 @@
+//
+//  BankView.swift
+//  BankManagerConsoleApp
+//
+//  Created by 루피, 진 on 2/6/24.
+//
+
+protocol BankViewProtocol {
+    func printConsolView(message: Any, terminator: String?)
+}
+
+struct BankView: BankViewProtocol {
+    
+    func printConsolView(message: Any, terminator: String?) {
+        if let terminator = terminator == nil ? "\n" : terminator?.description {
+            print(message, terminator: terminator)
+        }
+    }
+}


### PR DESCRIPTION
리뷰어: 다나 @songda515

버드: Jin @wlsdud-dev, Loffy @kimdj1102

---
안녕하세요~ 다나!

Jin, Loffy 입니다! 은행 창구 관리 앱 STEP3 PR 보냅니다!
프로젝트 중 Loffy의 건강상태가 좋지 못하여서 의논은 같이 했지만
작업은 Jin이 할 수 밖에 없었습니다.
이번 은행 관리 앱 프로젝트는 STEP3를 최종 목표로 진행 하였습니다.

## 프로젝트 구현 요구사항

### **Step 3 : 다중처리**

- Step 3의 은행에는 3명의 은행원이 근무합니다.
    - 2명의 은행원은 예금업무를, 1명의 은행원은 대출업무를 처리합니다.
    - 고객의 업무 종류는 고객 생성시 임의로 지정합니다.
- 한 명의 은행원은 한 명의 고객을 응대할 수 있습니다.
- 고객이 원하는 업무의 종류와 소요시간은 아래와 같습니다.
    - 대출 : 1.1초
    - 예금 : 0.7초
- 대기중인 고객의 업무처리를 시작할 때 아래와 같이 출력합니다.
    - "3번 고객 대출업무 시작"
- 고객의 업무를 처리하면 아래와 같이 출력합니다.
    - "11번 고객 예금업무 완료"

## 🤔고민이 되었던 점

### 동기와 비동기

step3는 은행원이 3명이고 각각 비동기로 처리하며 3명이 작업을 하는 도중에는 작업 처리를 미뤄야 한다는 조건이 상당히 어려운 부분이였습니다.

```swift
var depositWatingQueue = CustomerQueue<Customer>()
var loanWatingQueue = CustomerQueue<Customer>()

let depositSemaphore = DispatchSemaphore(value: 2)
let loanSemaphore = DispatchSemaphore(value: 1)

let watingGroup = DispatchGroup()
```

예금과 대출을 서로 나눠 처리 하기 위해 큐를 두개를 만들어 주었고
`Semaphore`를 이용해 `DispatchQueue`가 작업을 진행중이라면 접근을 막아 주었습니다.

`DispatchGroup` 를 이용해 비동기의 끝나는 시점에 대해 처리해 주었습니다.

**구현도중 시행착오를 겪은 부분**

1. `DispatchQueue` 를 호출하는 위치와 `Semaphore`의 위치에 난항을 겪었습니다.
2. 비동기의 끝난 시점을 캐치하는 방법
    
    `watingGroup.notify` 를 사용해 캐치하여 처리하려고 했지만 의도대로 동작하지 않았습니다.
    그래서 `watingGroup.wait()` 를 사용하여 구현은 했지만 `Semaphore` 의 동작이 제대로 되지 않는 상황입니다.
```swift
private func resetSetting() {
        depositSemaphore.signal()
        loanSemaphore.signal()
    }
```
    

### MVC패턴

콘솔창을 View라고 가정하고 MVC패턴을 적용 하였습니다.
MVC패턴을 잘 적용한건지 의문이 들었고 Bank가 너무 많은 책임과 일을 하는거 아닌가 라는 생각이 듭니다.

### 클래스와 구조체

클래스와 구조체를 이해 했다고 생각 했는데 이번 STEP3를 진행하면서 한참 모자라다는걸 깨달았습니다.
탈출 클로저와 구조체에서의 `[self] in` 이 왜 필요하고 클로저 안에서 구조체의 프로퍼티 접근을 하려면 어떻게 해야하는지 알지 못했습니다.
지역변수 였던 고객 카운트를 없애고`self.customerCount = Int.random(in: 10...30)` 로 실제 `dequeue`가 이뤄졌을때 카운트 값을 증가시키지는 못했습니다.